### PR TITLE
feat: add toast shelf

### DIFF
--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -18,13 +18,9 @@ const ICONS_BY_VARIANT = {
   error: AlertOctagon,
 };
 
-function Icon({icon: Icon}){
-  return(
-      <Icon size={24} />
-  );
-}
+function Toast({id, variant, onDelete, children}) {
+  const Icon = ICONS_BY_VARIANT[variant];
 
-function Toast({variant, onClose, children}) {
   return (
     <div className={`${styles.toast} ${styles[variant]}`}>
       <div className={styles.iconContainer}>
@@ -33,7 +29,7 @@ function Toast({variant, onClose, children}) {
       <p className={styles.content}>
         {children}
       </p>
-      <button className={styles.closeButton} onClick={()=>onClose(false)}>
+      <button className={styles.closeButton} onClick={() => onDelete(id)}>
         <X size={24} />
         <VisuallyHidden>Dismiss message</VisuallyHidden>
       </button>

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -6,14 +6,35 @@ import styles from './ToastPlayground.module.css';
 
 import Toast from '../Toast/Toast';
 
+import ToastShelf from '../ToastShelf/ToastShelf'
+
 const VARIANT_OPTIONS = ['notice', 'warning', 'success', 'error'];
+
+const TOAST_EXAMPLE = {
+  message: 'I am just an example of a toast',
+  variant: VARIANT_OPTIONS[0], 
+  id: crypto.randomUUID(),
+}
 
 function ToastPlayground() {
 
   const [message, setMessage] = React.useState('');
-  const [optionSelected, setOptionSelected] = React.useState(VARIANT_OPTIONS[0]);
+  const [variant, setVariant] = React.useState(VARIANT_OPTIONS[0]);
 
-  const [isToastVisible, setToastVisible] = React.useState(false);
+  const [toasts, setToasts] = React.useState([TOAST_EXAMPLE]);
+
+  const handlePopToast = () => {
+    const newToast = {
+      message,
+      variant: variant,
+      id: crypto.randomUUID()
+    }
+
+    setMessage('');
+    setVariant(VARIANT_OPTIONS[0])
+
+    setToasts([...toasts, newToast]);
+  }
 
   return (
     <div className={styles.wrapper}>
@@ -22,63 +43,66 @@ function ToastPlayground() {
         <h1>Toast Playground</h1>
       </header>
 
-      {isToastVisible && 
-        <Toast variant={optionSelected} onClose={setToastVisible}>
-          {message}
-        </Toast>
-      }
+      <ToastShelf toasts={toasts} onRemove={setToasts}/>
 
-      <div className={styles.controlsWrapper}>
-        <div className={styles.row}>
-          <label
-            htmlFor="message"
-            className={styles.label}
-            style={{ alignSelf: 'baseline' }}
-          >
-            Message
-          </label>
-          <div className={styles.inputWrapper}>
-            <textarea 
-              id="message" 
-              className={styles.messageInput} 
-              value={message} 
-              onChange={event => {
-                setMessage(
-                  event.target.value
-                )}}
-            />
+      <form 
+        onSubmit={(event)=>{
+          event.preventDefault();
+          handlePopToast();
+        }}
+      >
+        <div className={styles.controlsWrapper}>
+          <div className={styles.row}>
+            <label
+              htmlFor="message"
+              className={styles.label}
+              style={{ alignSelf: 'baseline' }}
+            >
+              Message
+            </label>
+            <div className={styles.inputWrapper}>
+              <textarea 
+                id="message" 
+                className={styles.messageInput} 
+                value={message} 
+                onChange={event => {
+                  setMessage(
+                    event.target.value
+                  )}}
+              />
+            </div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label}>Variant</div>
+            <div
+              className={`${styles.inputWrapper} ${styles.radioWrapper}`}
+            >
+              {VARIANT_OPTIONS.map((option, index)=>(
+                <label htmlFor={option} key={index}>
+                  <input 
+                    id={option} 
+                    type="radio" 
+                    name="variant" 
+                    value={option} 
+                    checked={option === variant} 
+                    onChange={(event)=>setVariant(event.target.value)}/>
+                  {option}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label} />
+            <div
+              className={`${styles.inputWrapper} ${styles.radioWrapper}`}
+            >
+              <Button>Pop Toast!</Button>
+            </div>
           </div>
         </div>
-
-        <div className={styles.row}>
-          <div className={styles.label}>Variant</div>
-          <div
-            className={`${styles.inputWrapper} ${styles.radioWrapper}`}
-          >
-            {VARIANT_OPTIONS.map((option, index)=>(
-              <label htmlFor={option} key={index}>
-                <input 
-                  id={option} 
-                  type="radio" 
-                  name="variant" 
-                  value={option} 
-                  checked={option === optionSelected} 
-                  onChange={(event)=>setOptionSelected(event.target.value)}/>
-                {option}
-              </label>
-            ))}
-          </div>
-        </div>
-
-        <div className={styles.row}>
-          <div className={styles.label} />
-          <div
-            className={`${styles.inputWrapper} ${styles.radioWrapper}`}
-          >
-            <Button onClick={()=>setToastVisible(true)}>Pop Toast!</Button>
-          </div>
-        </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/components/ToastShelf/ToastShelf.js
+++ b/src/components/ToastShelf/ToastShelf.js
@@ -3,15 +3,23 @@ import React from 'react';
 import Toast from '../Toast';
 import styles from './ToastShelf.module.css';
 
-function ToastShelf() {
+function ToastShelf({toasts, onRemove}) {
+
+  const handleToastRemoval = (id) => {
+    const newToasts = toasts.filter((toast) => {
+      return toast.id !== id;
+    })
+
+    onRemove(newToasts);
+  }
+
   return (
     <ol className={styles.wrapper}>
-      <li className={styles.toastWrapper}>
-        <Toast variant="notice">Example notice toast</Toast>
-      </li>
-      <li className={styles.toastWrapper}>
-        <Toast variant="error">Example error toast</Toast>
-      </li>
+      {toasts.map(({message, variant, id}) => (
+        <li className={styles.toastWrapper} key={id}>
+          <Toast id={id} variant={variant} onDelete={handleToastRemoval}>{message}</Toast>
+        </li>
+      ))}
     </ol>
   );
 }


### PR DESCRIPTION
Adds the Toast Shelf feature.

- New toasts are pushed onto a stack and rendered inside `ToastShelf`.
- When “Pop Toast!” is clicked, the message/variant form controls are reset to their default state.
- Clicking the “×” button inside the toast removes that specific toast.
- A `<form>` tag is now used in the ToastPlayground. The toast is now created when submitting the form.
- No key warnings!